### PR TITLE
Fix: Adjust ChatbotScreen padding to account for persistent taskbar

### DIFF
--- a/app/src/main/java/com/win11launcher/ui/components/ChatbotScreen.kt
+++ b/app/src/main/java/com/win11launcher/ui/components/ChatbotScreen.kt
@@ -25,6 +25,8 @@ import com.win11launcher.services.AIService
 import com.win11launcher.ui.theme.Win11Colors // Import Win11Colors
 import com.win11launcher.viewmodels.ChatbotViewModel
 
+private val TaskbarHeight = 56.dp
+
 @Composable
 fun ChatbotScreen() {
     val context = LocalContext.current
@@ -44,7 +46,8 @@ fun ChatbotScreen() {
         modifier = Modifier
             .fillMaxSize()
             .background(Win11Colors.SystemBackground) // Use Win11Colors
-            .windowInsetsPadding(WindowInsets.ime)
+            .windowInsetsPadding(WindowInsets.ime) // Handles keyboard
+            .padding(bottom = TaskbarHeight) // Handles persistent taskbar
     ) {
         LazyColumn(
             modifier = Modifier.weight(1f),


### PR DESCRIPTION
Previously, the ChatbotScreen's input field and messages could be obscured by the keyboard when the persistent system taskbar was present.

This change introduces a TaskbarHeight constant (56.dp) in ChatbotScreen.kt and adds this as bottom padding to the root Column, *after* the windowInsetsPadding(WindowInsets.ime). This ensures the chat content is pushed up by both the keyboard (when visible) and the persistent taskbar.